### PR TITLE
ci(workflows): disable automatic setup-node caching

### DIFF
--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
+          package-manager-cache: false
 
       - run: npm ci
 
@@ -86,7 +87,6 @@ jobs:
           ISSUE_PROJECT_QUERY: |
             org:mdn is:issue label:"needs content decision" ${{ env.COMMON_FILTER }}
             is:issue ${{ env.COMMON_FILTER }} ${{ env.CONTENT_REPO_FILTER }}
-
 
       - name: Engineering issues
         run: |

--- a/.github/workflows/add-prs-to-project.yml
+++ b/.github/workflows/add-prs-to-project.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
+          package-manager-cache: false
 
       - run: npm ci
 


### PR DESCRIPTION
### Description

Sets `package-manager-cache: false` to all `actions/setup-node` workflow steps that don't already have caching configured via either `package-manager-cache` or `cache`.

### Motivation

The new default behavior introduced in [`actions/setup-node v5.0.0`](https://github.com/actions/setup-node/releases/tag/v5.0.0) is not safe.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
