### PR TITLE
ci(workflows): pin 3rd party actions

### DIFF
--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -22,11 +22,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: ".nvmrc"
           package-manager-cache: false

--- a/.github/workflows/add-prs-to-project.yml
+++ b/.github/workflows/add-prs-to-project.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: ".nvmrc"
           package-manager-cache: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           cache: npm
           node-version-file: ".nvmrc"


### PR DESCRIPTION
### Description

Pins all 3rd party GitHub Actions to specific commit hashes instead of version tags.

Each pinned action includes an inline comment with the resolved version number for reference.

### Motivation

Security best practice to pin actions to immutable commit hashes, preventing potential supply chain attacks from compromised action versions or tag hijacking.

### Additional details

See: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1005.