### PR TITLE
feat(manage-project-items): support "last commenter" field

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -262,6 +262,13 @@ export async function* iterateProjectItems(orgName, projectNumber) {
                       createdAt
                       updatedAt
                       closedAt
+                      comments(last: 1) {
+                        nodes {
+                          author {
+                            login
+                          }
+                        }
+                      }
                     }
                     ... on PullRequest {
                       author {
@@ -274,6 +281,13 @@ export async function* iterateProjectItems(orgName, projectNumber) {
                       }
                       updatedAt
                       closedAt
+                      comments(last: 1) {
+                        nodes {
+                          author {
+                            login
+                          }
+                        }
+                      }
                     }
                   }
                 }

--- a/src/manage-project-items.js
+++ b/src/manage-project-items.js
@@ -56,6 +56,12 @@ const SUPPORTED_FIELDS = [
     getFieldValueValue: (field) => field?.text,
     createInput: (text) => ({ text }),
   },
+  {
+    is: (field) => isField(field, "last commenter", "text"),
+    getItemValue: (item) => item.content?.comments?.nodes.at(-1)?.author?.login,
+    getFieldValueValue: (field) => field?.text,
+    createInput: (text) => ({ text }),
+  },
 ];
 
 async function getUsedFields(projectOwner, projectNumber) {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Add support for managing the "last commenter" field.

### Motivation

Make it easier to identify whether someone has responded on an issue or PR.

### Additional details

Tested successfully with the [BCD issues](https://github.com/orgs/mdn/projects/47) and [Engineering issues](https://github.com/orgs/mdn/projects/36) projects.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
